### PR TITLE
Fix #21 Raise GrammarError on invalid grammars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Removed support for Python 3.6, 3.7 ([#23])
 * Added support for Python 3.10, 3.11 ([#23])
 
+### Fixed
+
+* Parse errors on loading a grammar are now GrammarError ([#21])
+
 
 ## [v0.3.2][]
 
@@ -132,4 +136,5 @@ descent parser and a work-in-progress state-machine parser.
 [#18]: https://github.com/goodmami/pe/issues/18
 [#19]: https://github.com/goodmami/pe/issues/19
 [#20]: https://github.com/goodmami/pe/issues/20
+[#21]: https://github.com/goodmami/pe/issues/21
 [#23]: https://github.com/goodmami/pe/issues/23

--- a/pe/_parse.py
+++ b/pe/_parse.py
@@ -74,7 +74,7 @@ The syntax is defined as follows::
 from typing import Tuple, Dict, cast
 
 import pe
-from pe._errors import Error
+from pe._errors import Error, ParseError, GrammarError
 from pe._definition import Definition
 from pe._grammar import Grammar
 from pe.operators import (
@@ -246,7 +246,13 @@ _parser = PackratParser(PEG)
 
 def loads(source: str) -> Tuple[str, Dict[str, Definition]]:
     """Parse the PEG at *source* and return a list of definitions."""
-    m = _parser.match(source, flags=pe.STRICT | pe.MEMOIZE)
+    if not source.strip():
+        raise GrammarError("empty grammar")
+    try:
+        m = _parser.match(source, flags=pe.STRICT | pe.MEMOIZE)
+    except ParseError as exc:
+        raise GrammarError("invalid grammar") from exc
+
     if not m:
         raise Error('invalid grammar')
     defs = m.value()

--- a/test/test__parse.py
+++ b/test/test__parse.py
@@ -1,4 +1,6 @@
+import pytest
 
+from pe._errors import GrammarError
 from pe.operators import (
     Dot,
     Literal,
@@ -118,3 +120,12 @@ def test_loads_def():
         Bee <- "b"
     ''') == ('A', {'A': Sequence('a', Nonterminal('Bee')),
                    'Bee': Literal('b')})
+
+
+def test_loads_error():
+    with pytest.raises(GrammarError):
+        loads('')
+    with pytest.raises(GrammarError):
+        loads('A <- +"a"')
+    with pytest.raises(GrammarError):
+        loads('A <- "a"+*')


### PR DESCRIPTION
ParserError is meant for errors during parsing with a successfully created grammar.