### PR TITLE
Fix 6 autoignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ ignore whitespace, so the default ignore pattern is simple whitespace.
 >>> pe.match("X <- 'a' 'b'", "a b")  # regular rule does not match
 >>> pe.match("X <  'a' 'b'", "a b")  # auto-ignore rule matches
 <Match object; span=(0, 3), match='a b'>
+
 ```
 
 This feature can help to make grammars more readable.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The grammar can be defined such that some rules ignore occurrences of
 a pattern between sequence items. Most commonly, this is used to
 ignore whitespace, so the default ignore pattern is simple whitespace.
 
-```pycon
+```python
 >>> pe.match("X <- 'a' 'b'", "a b")  # regular rule does not match
 >>> pe.match("X <  'a' 'b'", "a b")  # auto-ignore rule matches
 <Match object; span=(0, 3), match='a b'>

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ name:e       # bind result of e to 'name'
 # grammars
 Name <- ...  # define a rule named 'Name'
 ... <- Name  # refer to rule named 'Name'
+
+# (extension) auto-ignore
+X <  e1 e2   # define a rule 'X' with auto-ignore
 ```
 
 ## Matching Inputs with Parsing Expressions
@@ -184,6 +187,19 @@ func(sep.join(match.groups()), **match.groupdict())
 [Pack]: docs/api/pe.actions.md#Pack
 [Join]: docs/api/pe.actions.md#Join
 
+### Auto-ignore
+
+The grammar can be defined such that some rules ignore occurrences of
+a pattern between sequence items. Most commonly, this is used to
+ignore whitespace, so the default ignore pattern is simple whitespace.
+
+```pycon
+>>> pe.match("X <- 'a' 'b'", "a b")  # regular rule does not match
+>>> pe.match("X <  'a' 'b'", "a b")  # auto-ignore rule matches
+<Match object; span=(0, 3), match='a b'>
+```
+
+This feature can help to make grammars more readable.
 
 ### Example
 
@@ -195,10 +211,10 @@ Here is one way to parse a list of comma-separated integers:
 ...   r'''
 ...     Start  <- "[" Values? "]"
 ...     Values <- Int ("," Int)*
-...     Int    <- ~( "-"? ("0" / [1-9] [0-9]*) )
+...     Int    <  ~( "-"? ("0" / [1-9] [0-9]*) )
 ...   ''',
 ...   actions={'Values': Pack(list), 'Int': int})
->>> m = p.match('[5,10,-15]')
+>>> m = p.match('[5, 10, -15]')
 >>> m.value()
 [5, 10, -15]
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 * [Specification](specification.md)
 * [Guides](guides/README.md)
   - [Matching strings with pe.match()](guides/basic-matching.md)
+  - [Ignoring whitespace by default](guides/using-autoignore.md)
   - [Transform results with semantic actions](guides/using-actions.md)
   - [Controlling parser behavior with flags](guides/using-flags.md)
   - [Common patterns](guides/common-patterns.md)

--- a/docs/api/pe.machine.md
+++ b/docs/api/pe.machine.md
@@ -3,5 +3,5 @@
 
 
 *class* pe.machine.**<a id="MachineParser" href="#MachineParser">MachineParser</a>**
-(*grammar, flags=pe.NONE*)
+(*grammar, ignore=pe.patterns.DEFAULT_IGNORE, flags=pe.NONE*)
 

--- a/docs/api/pe.md
+++ b/docs/api/pe.md
@@ -4,7 +4,7 @@
 ## Functions
 
 * pe.**<a id="compile" href="#compile">compile</a>**
-  (*source, actions=None, parser='packrat', flags=pe.OPTIMIZE*)
+  (*source, actions=None, parser='packrat', ignore=pe.patterns.DEFAULT_IGNORE, flags=pe.OPTIMIZE*)
 
   Compile the parsing expression or grammar defined in *source* and
   return the [Parser](#Parser) object. If *source* contains a grammar
@@ -21,6 +21,9 @@
   implementation. By default this is `'packrat'` for the
   [packrat](pe.packrat.md) *parser*, but it can be set to `"machine"`
   to use the state machine parser.
+
+  The *ignore* pattern is the definition used by autoignore. Set to
+  `None` to disable autoignore.
 
   The *flags* argument can be used to affect how the parser is
   initialized. By default it is [pe.OPTIMIZE](#OPTIMIZE), but
@@ -49,7 +52,7 @@
 
 
 * pe.**<a id="match" href="#match">match</a>**
-  (*pattern, string, actions=None, parser='packrat', flags=pe.MEMOIZE | pe.STRICT*)
+  (*pattern, string, actions=None, parser='packrat', ignore=pe.patterns.DEFAULT_IGNORE, flags=pe.MEMOIZE | pe.STRICT*)
 
   Match the parsing expression defined in *pattern* against the input
   *string*.
@@ -58,6 +61,9 @@
   *parser* is used. The *parser* parameter can be set to `"machine"`
   to use the state machine parser, but for more control over grammar
   compilation use the [compile()](#compile) function.
+
+  The *ignore* pattern is the definition used by autoignore. Set to
+  `None` to disable autoignore.
 
   The *flags* parameter is used to affect parsing behavior; by default
   it uses [pe.MEMOIZE](#MEMOIZE). Note that changing this value will

--- a/docs/api/pe.operators.md
+++ b/docs/api/pe.operators.md
@@ -109,3 +109,10 @@ the rest are described by the [specification](../specification.md).
   manually and it has no representation in the grammar notation, but
   rather it is inserted semi-automatically by compiling a grammar with
   the [pe.DEBUG](pe.md#DEBUG) flag.
+
+* pe.operators.**<a id="AutoIgnore" href="#AutoIgnore">AutoIgnore</a>**
+  (*expression*)
+
+  Interleave the "ignore" pattern around and between sequence items.
+  The ignore pattern is passed to the parser and defaults to
+  [pe.patterns.DEFAULT_IGNORE](pe.patterns#DEFAULT_IGNORE).

--- a/docs/api/pe.packrat.md
+++ b/docs/api/pe.packrat.md
@@ -3,5 +3,5 @@
 
 
 *class* pe.packrat.**<a id="PackratParser" href="#PackratParser">PackratParser</a>**
-(*grammar, flags=pe.NONE*)
+(*grammar, ignore=pe.patterns.DEFAULT_IGNORE, flags=pe.NONE*)
 

--- a/docs/api/pe.patterns.md
+++ b/docs/api/pe.patterns.md
@@ -1,0 +1,8 @@
+
+# API Reference: pe.patterns
+
+
+* pe.patterns.**<a id="DEFAULT_IGNORE" href="#DEFAULT_IGNORE">DEFAULT_IGNORE</a>**
+
+  The default pattern used in autoignore functionality. Set to
+  single-line ASCII whitespace: `[ \t]*`

--- a/docs/guides/using-autoignore.md
+++ b/docs/guides/using-autoignore.md
@@ -1,0 +1,59 @@
+
+# Ignoring Whitespace by Default
+
+Basic parsing expression grammars (PEGs) do not formally define tokens
+separately from other grammar rules, and as such it is not possible to
+tell the parser to ignore all tokens of a certain type, such as
+whitespace. This is why PEGs often have rules like this (a subset of a
+JSON grammar):
+
+```peg
+Array    <- LBRACKET Value (COMMA Value)* RBRACKET
+
+LBRACKET <- "[" Spacing
+RBRACKET <- "]" Spacing
+COMMA    <- "," Spacing
+```
+
+Wherever whitespace may occur, it must be defined by the grammar.
+
+As an extension to standard PEG syntax, **pe** allows "autoignore"
+rules via the `< ` rule operator (inspired by the [space arrow][] from
+the [Pegged][] parser), which transforms the grammar to interleave a
+particular pattern around and between sequence items. The above
+grammar then becomes:
+
+```peg
+Array    <- LBRACKET Value (COMMA Value)* RBRACKET
+
+LBRACKET <- "["
+RBRACKET <- "]"
+COMMA    <- ","
+```
+
+or even:
+
+```peg
+Array    <  "[" Value ("," Value)* "]"
+```
+
+Only grammar rules that use the `< ` rule operator will use
+autoignore. By default, the ignore pattern is
+[pe.patterns.DEFAULT_IGNORE](pe.patterns#DEFAULT_IGNORE), but it can be customized by changing the `ignore` parameter when compiling a grammar:
+
+```python
+import pe
+from pe.operators import Star, Class
+g = pe.compile(r"'a' 'b'", ignore=Star(Class(" \t\n\r\v\f")))
+```
+
+Currently the value of the `ignore` parameter must be constructed
+using [pe.operators](../api/pe.operators.md), but this may change in
+the future.
+
+Finally, any semantics in the ignore pattern, such as captures,
+bindings, or actions, will be stripped out of the definition so there
+is no semantic effect of parsing the ignore pattern.
+
+[space arrow]: https://github.com/PhilippeSigaud/Pegged/wiki/Extended-PEG-Syntax#space-arrow-and-user-defined-spacing
+[Pegged]: https://github.com/PhilippeSigaud/Pegged

--- a/docs/guides/using-autoignore.md
+++ b/docs/guides/using-autoignore.md
@@ -39,9 +39,9 @@ Array    <  "[" Value ("," Value)* "]"
 
 Only grammar rules that use the `< ` rule operator will use
 autoignore. By default, the ignore pattern is
-[pe.patterns.DEFAULT_IGNORE](pe.patterns#DEFAULT_IGNORE), but it can
-be customized by changing the `ignore` parameter when compiling a
-grammar:
+[pe.patterns.DEFAULT_IGNORE](../api/pe.patterns#DEFAULT_IGNORE), but
+it can be customized by changing the `ignore` parameter when compiling
+a grammar:
 
 ```python
 import pe

--- a/docs/guides/using-autoignore.md
+++ b/docs/guides/using-autoignore.md
@@ -39,7 +39,7 @@ Array    <  "[" Value ("," Value)* "]"
 
 Only grammar rules that use the `< ` rule operator will use
 autoignore. By default, the ignore pattern is
-[pe.patterns.DEFAULT_IGNORE](../api/pe.patterns#DEFAULT_IGNORE), but
+[pe.patterns.DEFAULT_IGNORE](../api/pe.patterns.md#DEFAULT_IGNORE), but
 it can be customized by changing the `ignore` parameter when compiling
 a grammar:
 

--- a/docs/guides/using-autoignore.md
+++ b/docs/guides/using-autoignore.md
@@ -18,13 +18,13 @@ COMMA    <- "," Spacing
 Wherever whitespace may occur, it must be defined by the grammar.
 
 As an extension to standard PEG syntax, **pe** allows "autoignore"
-rules via the `< ` rule operator (inspired by the [space arrow][] from
-the [Pegged][] parser), which transforms the grammar to interleave a
-particular pattern around and between sequence items. The above
-grammar then becomes:
+rules via the `< ` rule operator (inspired by the [space arrow from
+the Pegged parser][space arrow]), which transforms the grammar to
+interleave a particular pattern around and between sequence items. The
+above grammar then becomes:
 
 ```peg
-Array    <- LBRACKET Value (COMMA Value)* RBRACKET
+Array    <  LBRACKET Value (COMMA Value)* RBRACKET
 
 LBRACKET <- "["
 RBRACKET <- "]"
@@ -39,7 +39,9 @@ Array    <  "[" Value ("," Value)* "]"
 
 Only grammar rules that use the `< ` rule operator will use
 autoignore. By default, the ignore pattern is
-[pe.patterns.DEFAULT_IGNORE](pe.patterns#DEFAULT_IGNORE), but it can be customized by changing the `ignore` parameter when compiling a grammar:
+[pe.patterns.DEFAULT_IGNORE](pe.patterns#DEFAULT_IGNORE), but it can
+be customized by changing the `ignore` parameter when compiling a
+grammar:
 
 ```python
 import pe
@@ -56,4 +58,3 @@ bindings, or actions, will be stripped out of the definition so there
 is no semantic effect of parsing the ignore pattern.
 
 [space arrow]: https://github.com/PhilippeSigaud/Pegged/wiki/Extended-PEG-Syntax#space-arrow-and-user-defined-spacing
-[Pegged]: https://github.com/PhilippeSigaud/Pegged

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -45,7 +45,8 @@ following sections.
 | (none)   | [Rule]        | [Applicative] | Match sequential term `s`, apply the defined action       |
 | `a`      | (default)     | [Prioritized] | Match applicative term `a`                                |
 | `a / e`  | [Choice]      | [Prioritized] | Match prioritized term `e` only if `a` failed             |
-| `A <- e` | [Grammar]     | [Definitive]  | Match prioritized term `e` for start symbol `A`           |
+| `A <- e` | [Grammar]     | [Definitive]  | Define `A` as the prioritized term `e`                    |
+| `A <  e` | [Grammar]     | [Definitive]  | Define `A` as the prioritized term `e` with autoignore    |
 
 
 ## Grammar Syntax
@@ -60,11 +61,11 @@ describing itself. This PEG is based on Bryan Ford's original
 # Hierarchical syntax
 Start      <- Spacing (Grammar / Expression) EndOfFile
 Grammar    <- Definition+
-Definition <- Identifier Operator Expression
-Operator   <- LEFTARROW
+Definition <- Identifier defop:Operator Expression
+Operator   <- LEFTARROW / LEFTANGLE
 Expression <- Sequence (SLASH Sequence)*
-Sequence   <- Evaluated*
-Evaluated  <- (prefix:Prefix)? Quantified
+Sequence   <- Valued*
+Valued     <- (prefix:Prefix)? Quantified
 Prefix     <- AND / NOT / TILDE / Binding
 Binding    <- Identifier COLON
 Quantified <- Primary (quantifier:Quantifier)?
@@ -93,6 +94,7 @@ Oct        <- [0-7]
 Hex        <- [0-9a-fA-F]
 
 LEFTARROW  <- '<-' Spacing
+LEFTANGLE  <- '<' Space Spacing
 SLASH      <- '/' Spacing
 AND        <- '&' Spacing
 NOT        <- '!' Spacing
@@ -198,6 +200,7 @@ expressions compared to the equivalent in-situ expression.
 | (none)         | [Rule]     | 2          | [Applicative]   |
 | `e1 / e2`      | [Choice]   | 1          | [Prioritized]   |
 | `Abc <- e`     | [Grammar]  | 0          | [Definitive]    |
+| `Abc <  e`     | [Grammar]  | 0          | [Definitive]    |
 
 
 ## Expression Values and Behavior

--- a/pe/_autoignore.py
+++ b/pe/_autoignore.py
@@ -1,0 +1,64 @@
+from typing import Optional
+
+from pe._constants import Operator
+from pe._definition import Definition
+from pe._grammar import Grammar
+from pe.operators import Sequence
+
+
+def autoignore(grammar: Grammar, ignore: Optional[Definition]) -> Grammar:
+    """Interleave ignore patterns around sequence items."""
+    new = {
+        name: _autoignore(defn, ignore)
+        for name, defn
+        in grammar.definitions.items()
+    }
+    return Grammar(
+        definitions=new,
+        actions=grammar.actions,
+        start=grammar.start
+    )
+
+
+_single_expr_ops = {
+    Operator.OPT,
+    Operator.STR,
+    Operator.PLS,
+    Operator.AND,
+    Operator.NOT,
+    Operator.CAP,
+    Operator.BND,
+    Operator.RUL,
+    Operator.DEF,
+}
+
+_multi_expr_ops = {
+    Operator.SEQ,
+    Operator.CHC,
+}
+
+
+def _autoignore(defn: Definition, ignore: Optional[Definition]) -> Definition:
+    if defn.op == Operator.IGN:
+        subdef = _autoignore(defn.args[0], ignore)
+        if ignore is not None:
+            if subdef.op == Operator.SEQ:
+                items = [ignore]
+                for item in subdef.args[0]:
+                    items.append(item)
+                    items.append(ignore)
+            else:
+                items = [ignore, subdef, ignore]
+            subdef = Sequence(*items)
+        defn = subdef
+    elif defn.op in _single_expr_ops:
+        args = defn.args
+        defn = Definition(defn.op, (_autoignore(args[0], ignore), *args[1:]))
+    elif defn.op in _multi_expr_ops:
+        args = defn.args
+        defn = Definition(
+            defn.op,
+            ([_autoignore(arg, ignore) for arg in args[0]], *args[1:])
+        )
+    # do nothing for primary expressions
+    return defn

--- a/pe/_constants.py
+++ b/pe/_constants.py
@@ -28,6 +28,7 @@ class Operator(enum.Enum):
     NOT = (_auto(), 4, 'Valued')       # (NOT, (expr,))
     CAP = (_auto(), 4, 'Valued')       # (CAP, (expr,))
     BND = (_auto(), 4, 'Valued')       # (BND, (expr, name))
+    IGN = (_auto(), 4, 'Valued')       # (IGN, (expr,))
     SEQ = (_auto(), 3, 'Sequential')   # (SEQ, (exprs,))
     RUL = (_auto(), 2, 'Applicative')  # (RUL, (expr, action, name))
     CHC = (_auto(), 1, 'Prioritized')  # (CHC, (exprs,))

--- a/pe/_constants.py
+++ b/pe/_constants.py
@@ -43,6 +43,9 @@ class Operator(enum.Enum):
     def type(self):
         return self.value[2]
 
+    def is_unary(self):
+        return self.type not in {'Sequential', 'Prioritized'}
+
 
 class Flag(enum.Flag):
     NONE = 0

--- a/pe/_cy_machine.pyx
+++ b/pe/_cy_machine.pyx
@@ -16,11 +16,14 @@ from pe._constants import Operator, Flag
 from pe._errors import Error
 from pe._match import Match
 from pe._types import Memo
+from pe._definition import Definition
 from pe._grammar import Grammar
 from pe._parser import Parser
 from pe._optimize import optimize
+from pe._autoignore import autoignore
 from pe.actions import Action, Bind
 from pe.operators import Rule
+from pe.patterns import DEFAULT_IGNORE
 
 
 DEF FAILURE = -1
@@ -130,8 +133,11 @@ _Program = List[Instruction]
 class MachineParser(Parser):
 
     def __init__(self, grammar: Grammar,
+                 ignore: Optional[Definition] = DEFAULT_IGNORE,
                  flags: Flag = Flag.NONE):
         super().__init__(grammar, flags=flags)
+
+        grammar = autoignore(grammar, ignore)
 
         grammar = optimize(grammar,
                            inline=flags & Flag.INLINE,

--- a/pe/_definition.py
+++ b/pe/_definition.py
@@ -19,6 +19,7 @@ NOT = Operator.NOT
 CAP = Operator.CAP
 BND = Operator.BND
 SEQ = Operator.SEQ
+IGN = Operator.IGN
 CHC = Operator.CHC
 RUL = Operator.RUL
 DEF = Operator.DEF
@@ -87,6 +88,7 @@ _format_decorators: Dict[Operator, Tuple[str, str, str]] = {
     CAP: ('~', '', ''),
     BND: ('{}:', '', ''),
     SEQ: ('', ' ', ''),
+    IGN: ('<', '', ''),
     CHC: ('', ' / ', ''),
     RUL: ('', '', '  -> {}'),
 }
@@ -126,6 +128,7 @@ _format_map: Dict[Operator, _Formatter] = {
     CAP: _format_recursive,
     BND: _format_recursive,
     SEQ: _format_recursive,
+    IGN: _format_recursive,
     CHC: _format_recursive,
     RUL: _format_recursive,
     DBG: _format_debug,

--- a/pe/_disarm.py
+++ b/pe/_disarm.py
@@ -1,0 +1,25 @@
+from pe._constants import Operator
+from pe._definition import Definition
+
+
+def disarm(defn: Definition) -> Definition:
+    """Remove semantic effects like actions, binds, or captures."""
+    op = defn.op
+    if op in {Operator.RUL, Operator.BND, Operator.CAP}:
+        return disarm(defn.args[0])
+    elif op.type == 'Primary':
+        return defn
+    elif op == Operator.DBG:
+        subdef = disarm(defn.args[0])
+        if subdef.op == Operator.DBG:
+            return subdef  # collapse debug nodes
+        return Definition(op, (subdef,))
+    elif op.is_unary():
+        args = defn.args
+        return Definition(op, (disarm(args[0]), *args[1:]))
+    else:
+        args = defn.args
+        return Definition(
+            op,
+            ([disarm(arg) for arg in args[0]], *args[1:])
+        )

--- a/pe/_functions.py
+++ b/pe/_functions.py
@@ -3,10 +3,12 @@ from typing import Union, Dict, Callable, Optional
 
 from pe.actions import Action
 from pe._constants import Flag
+from pe._definition import Definition
 from pe._errors import Error
 from pe._parser import Parser
 from pe._grammar import Grammar
 from pe._parse import loads
+from pe.patterns import DEFAULT_IGNORE
 
 _FuncMap = Dict[str, Union[Action, Callable]]
 
@@ -14,6 +16,7 @@ _FuncMap = Dict[str, Union[Action, Callable]]
 def compile(source: Union[str, Grammar],
             actions: Optional[_FuncMap] = None,
             parser: str = 'packrat',
+            ignore: Optional[Definition] = DEFAULT_IGNORE,
             flags: Flag = Flag.OPTIMIZE) -> Parser:
     """Compile the parsing expression or grammar in *source*."""
     parsername = parser.lower()
@@ -39,7 +42,7 @@ def compile(source: Union[str, Grammar],
         print('## Grammar ##')
         print(g)
 
-    p = parser_class(g, flags=flags)
+    p = parser_class(g, ignore=ignore, flags=flags)
 
     if (flags & Flag.DEBUG) and (flags & Flag.OPTIMIZE):
         print('## Modified Grammar ##')
@@ -52,6 +55,7 @@ def match(pattern: str,
           string: str,
           actions: Optional[_FuncMap] = None,
           parser: str = 'packrat',
+          ignore: Optional[Definition] = DEFAULT_IGNORE,
           flags: Flag = Flag.MEMOIZE):
     """Compile *pattern* and match *string* against it.
 
@@ -63,5 +67,6 @@ def match(pattern: str,
     expr = compile(pattern,
                    actions=actions,
                    parser=parser,
+                   ignore=ignore,
                    flags=Flag.OPTIMIZE)
     return expr.match(string, flags=flags)

--- a/pe/_parser.py
+++ b/pe/_parser.py
@@ -1,5 +1,5 @@
 
-from typing import Union
+from typing import Union, Optional
 
 from pe._constants import Flag
 from pe._match import Match
@@ -14,6 +14,7 @@ class Parser:
 
     def __init__(self,
                  grammar: Union[Grammar, Definition],
+                 ignore: Optional[Definition] = None,
                  flags: Flag = Flag.NONE):
         if isinstance(grammar, Definition):
             grammar = Grammar({'Start': grammar})

--- a/pe/_py_machine.py
+++ b/pe/_py_machine.py
@@ -14,11 +14,14 @@ from pe._constants import FAIL as FAILURE, Operator, Flag
 from pe._errors import Error
 from pe._match import Match
 from pe._types import Memo
+from pe._definition import Definition
 from pe._grammar import Grammar
 from pe._parser import Parser
 from pe._optimize import optimize
+from pe._autoignore import autoignore
 from pe.actions import Action, Bind
 from pe.operators import Rule
+from pe.patterns import DEFAULT_IGNORE
 
 
 # Parser ###############################################################
@@ -94,8 +97,11 @@ def Instruction(
 class MachineParser(Parser):
 
     def __init__(self, grammar: Grammar,
+                 ignore: Optional[Definition] = DEFAULT_IGNORE,
                  flags: Flag = Flag.NONE):
         super().__init__(grammar, flags=flags)
+
+        grammar = autoignore(grammar, ignore)
 
         grammar = optimize(grammar,
                            inline=flags & Flag.INLINE,

--- a/pe/operators.py
+++ b/pe/operators.py
@@ -21,6 +21,7 @@ NOT = Operator.NOT
 CAP = Operator.CAP
 BND = Operator.BND
 SEQ = Operator.SEQ
+IGN = Operator.IGN
 CHC = Operator.CHC
 RUL = Operator.RUL
 DBG = Operator.DBG
@@ -162,6 +163,10 @@ def Rule(expression: _Def, action: Union[Action, Callable], name: str = ANONYMOU
 
 def Debug(expression: _Def):
     return Definition(DBG, (_validate(expression),))
+
+
+def AutoIgnore(expression: _Def):
+    return Definition(IGN, (_validate(expression),))
 
 
 class SymbolTable(Dict[str, Definition]):

--- a/pe/packrat.py
+++ b/pe/packrat.py
@@ -26,9 +26,11 @@ from pe._types import RawMatch, Memo
 from pe._grammar import Grammar
 from pe._parser import Parser
 from pe._optimize import optimize, regex
+from pe._autoignore import autoignore
 from pe._debug import debug
 from pe._misc import ansicolor
 from pe.actions import Action
+from pe.patterns import DEFAULT_IGNORE
 
 
 _Matcher = Callable[[str, int, Memo], RawMatch]
@@ -36,8 +38,15 @@ _Matcher = Callable[[str, int, Memo], RawMatch]
 
 class PackratParser(Parser):
 
-    def __init__(self, grammar: Grammar, flags: Flag = Flag.NONE):
+    def __init__(
+        self,
+        grammar: Grammar,
+        ignore: Optional[Definition] = DEFAULT_IGNORE,
+        flags: Flag = Flag.NONE
+    ):
         super().__init__(grammar, flags=flags)
+
+        grammar = autoignore(grammar, ignore)
 
         grammar = optimize(grammar,
                            inline=flags & Flag.INLINE,

--- a/pe/patterns.py
+++ b/pe/patterns.py
@@ -1,0 +1,6 @@
+from pe.operators import (
+    Class,
+    Star,
+)
+
+DEFAULT_IGNORE = Star(Class(' \t'))

--- a/test/test__disarm.py
+++ b/test/test__disarm.py
@@ -1,0 +1,14 @@
+from pe._definition import Definition
+from pe.operators import Bind, Capture, Literal, Rule, Sequence, Debug
+from pe._disarm import disarm
+
+
+def test_disarm():
+    assert disarm(Capture("foo")) == Literal("foo")
+    assert disarm(Bind("foo", "x")) == Literal("foo")
+    assert disarm(Rule(Capture("foo"), str.upper)) == Literal("foo")
+    assert (
+        disarm(Sequence(Capture("foo"), Capture("bar")))
+        == Sequence(Literal("foo"), Literal("bar"))
+    )
+    assert disarm(Debug(Capture(Debug("foo")))) == Debug(Literal("foo"))

--- a/test/test__parse.py
+++ b/test/test__parse.py
@@ -15,6 +15,7 @@ from pe.operators import (
     Not,
     Capture,
     Bind,
+    AutoIgnore,
 )
 from pe._parse import loads
 
@@ -120,6 +121,13 @@ def test_loads_def():
         Bee <- "b"
     ''') == ('A', {'A': Sequence('a', Nonterminal('Bee')),
                    'Bee': Literal('b')})
+
+
+def test_loads_autoignore_def():
+    assert loads('A <  "a"') == ('A', {'A': AutoIgnore('a')})
+    assert loads('A <  ~"a"') == ('A', {'A': AutoIgnore(Capture('a'))})
+    assert loads('A <  "a"*') == ('A', {'A': AutoIgnore(Star('a'))})
+    assert loads('A <  "a" "b"') == ('A', {'A': AutoIgnore(Sequence('a', 'b'))})
 
 
 def test_loads_error():

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -16,6 +16,7 @@ from pe.operators import (
     Not,
     Capture,
     Bind,
+    AutoIgnore,
 )
 
 
@@ -96,3 +97,8 @@ def test_Capture():
 def test_Bind():
     assert Bind(Dot(), name='x') == Def(Op.BND, (Dot(), 'x'))
     assert Bind('foo', name='bar') == Bind(Literal('foo'), name='bar')
+
+
+def test_AutoIgnore():
+    assert AutoIgnore(Dot()) == Def(Op.IGN, (Dot(),))
+    assert AutoIgnore('foo') == AutoIgnore(Literal('foo'))

--- a/test/test_parsers.py
+++ b/test/test_parsers.py
@@ -19,6 +19,7 @@ from pe.operators import (
     Sequence as Seq,
     Choice as Chc,
     Rule as Rul,
+    AutoIgnore as Ign,
 )
 from pe._grammar import Grammar
 from pe.actions import Pack
@@ -138,6 +139,17 @@ data = [  # noqa: E127
     ('Rgr1', Cap(Sym('abcs')), 'aaa',   0, 3,    (('aaa',), {}, 'aaa')),
     ('Rgr2', Seq(abc, Not(Dot())),
                               'a',      0, 1,    _blank),
+
+    ('Ign0', Ign(abc),        'a',      0, 1,    _blank),
+    ('Ign1', Ign(abc),        ' a  ',   0, 4,    _blank),
+    ('Ign2', Ign(abc),        ' x  ',   0, FAIL, None),
+    ('Ign3', Ign(abseq),      ' a b ',  0, 5,    _blank),
+    ('Ign4', Ign(Pls(xyz)),   ' xy ',   0, 4,    _blank),
+    ('Ign5', Ign(Pls(xyz)),   ' x y ',  0, 3,    _blank),
+    ('Ign6', Ign(Str(xyz)),   ' a ',    0, 1,    _blank),
+    ('Ign7', Ign(Pls(abseq)), ' abab ', 0, 6,    _blank),
+    ('Ign8', Ign(Pls(abseq)), ' ab ab', 0, 4,    _blank),
+    ('Ign9', Ign(Pls(abseq)), 'a ba b', 0, FAIL, None),
 
 ]
 


### PR DESCRIPTION
Implements autoignore functionality as follows:

1. `pe.compile()` and `pe.match()` now take an `ignore` parameter for patterns to ignore in some sequences.
2. The PEG metasyntax now has an additional definition operator `< `. E.g., in the example below, the `AB1` rule will only parse `ab`, but the `AB2` rule will also parse `a b`, ` ab`, ` a b `, etc. (depending on the definition of the `ignore` parameter).
   ```peg
   AB1 <- "a" "b"
   AB2 <  "a" "b"
   ```

This is a naive implementation that interleaves the ignore pattern around all elements of a sequence (or makes a sequence if the definition was not one already). It is therefore a bit inefficient in that the ignore parameter may be called multiple times in a row.

Closes #6

Remaining tasks:
- [x] sanitize `ignore` patterns from captures, bindings, or actions
- [x] api documentation
- [x] guide documentation