### PR TITLE
Escape special characters in the debug output

### DIFF
--- a/pe/packrat.py
+++ b/pe/packrat.py
@@ -298,7 +298,7 @@ class PackratParser(Parser):
         def _match(s: str, pos: int, memo: Memo) -> RawMatch:
             # for proper printing, only terminals can print after
             # knowing the result
-            snippet = f"{repr(s[pos:pos+10])[1:-2][:12]:<12}"
+            snippet = f"{repr(s[pos:pos+10])[1:-1][:12]:<12}"
             if subdef.op.precedence == 6 and subdef.op != Operator.SYM:
                 end, args, kwargs = expression(s, pos, memo)
                 indent = ' ' * len(inspect.stack(0))

--- a/pe/packrat.py
+++ b/pe/packrat.py
@@ -298,15 +298,16 @@ class PackratParser(Parser):
         def _match(s: str, pos: int, memo: Memo) -> RawMatch:
             # for proper printing, only terminals can print after
             # knowing the result
+            snippet = f"{repr(s[pos:pos+10])[1:-2][:12]:<12}"
             if subdef.op.precedence == 6 and subdef.op != Operator.SYM:
                 end, args, kwargs = expression(s, pos, memo)
                 indent = ' ' * len(inspect.stack(0))
                 color = 'green' if end >= 0 else 'red'
                 defstr = ansicolor(color, str(subdef))
-                print(f'{s[pos:pos+10]:<12} | {indent}{defstr}')
+                print(f'{snippet} | {indent}{defstr}')
             else:
-                print('{:<12} | {}{!s}'.format(
-                    s[pos:pos+10],
+                print('{} | {}{!s}'.format(
+                    snippet,
                     ' ' * len(inspect.stack(0)),
                     str(subdef)))
                 end, args, kwargs = expression(s, pos, memo)

--- a/pe/packrat.py
+++ b/pe/packrat.py
@@ -298,7 +298,7 @@ class PackratParser(Parser):
         def _match(s: str, pos: int, memo: Memo) -> RawMatch:
             # for proper printing, only terminals can print after
             # knowing the result
-            snippet = f"{repr(s[pos:pos+10])[1:-1][:12]:<12}"
+            snippet = s.encode("unicode_escape").decode("ascii")[:12].ljust(12)
             if subdef.op.precedence == 6 and subdef.op != Operator.SYM:
                 end, args, kwargs = expression(s, pos, memo)
                 indent = ' ' * len(inspect.stack(0))

--- a/pe/packrat.py
+++ b/pe/packrat.py
@@ -290,6 +290,23 @@ class PackratParser(Parser):
         subdef, action, name = definition.args
         expression = self._def_to_expr(subdef)
         return Rule(name, expression, action)
+    
+    @staticmethod
+    def _format_snippet(text: str) -> str:
+        """Escape any characters that create large amounts of whitespace,
+        mainly line breaking characters like newlines but also tabs.
+        """
+        offending_characters = str.maketrans({
+            "\n" : r"\n", # newline
+            "\r" : r"\r", # carriage return
+            "\v" : r"\v", # vertical tab
+            "\t" : r"\t", # horizontal tab
+            "\f" : r"\f", # form feed
+            "\u0085" : r"\u0085", # NEL next line
+            "\u2028" : r"\u2028", # \N{LINE SEPARATOR}
+            "\u2029" : r"\u2029", # \N{PARAGRAPH SEPARATOR}
+        })
+        return text.translate(offending_characters)
 
     def _debug(self, definition: Definition) -> _Matcher:
         subdef: Definition = definition.args[0]
@@ -298,7 +315,8 @@ class PackratParser(Parser):
         def _match(s: str, pos: int, memo: Memo) -> RawMatch:
             # for proper printing, only terminals can print after
             # knowing the result
-            snippet = s.encode("unicode_escape").decode("ascii")[:12].ljust(12)
+            snippet = self._format_snippet(s[pos:pos+10])[:10].ljust(12)
+
             if subdef.op.precedence == 6 and subdef.op != Operator.SYM:
                 end, args, kwargs = expression(s, pos, memo)
                 indent = ' ' * len(inspect.stack(0))

--- a/test/test_parsers.py
+++ b/test/test_parsers.py
@@ -165,3 +165,8 @@ def test_exprs(parser, dfn, input, pos, end, match):
         assert m.groups() == groups
         assert m.groupdict() == groupdict
         assert m.value() == value
+
+def test_snippet_escaping():
+    input = "😊\nあ\rA\vB\tC\fD\u0085E\u2028F\u2029"       
+    output = r"😊\nあ\rA\vB\tC\fD\u0085E\u2028F\u2029"    
+    assert PackratParser._format_snippet(input) == output


### PR DESCRIPTION
When debugging multiline strings I found it a bit difficult to read because the newlines were being printed. Wrapping the snippet in repr fixes this. I then had to add [1:-2] to cut off the quotes that repr introduces.

The only problem this introduces is that if the string contains many special characters it will be more than 12 characters long and hence break the nice formatting.

So I added an additional [:12] on the basis that even though it will sometimes break up the special characters you'll be able to tell that from the line above.

Nice library!