### PR TITLE
Group quantized literals in regex optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+* Group quantized 2+ char literals in regex optimization ([#54])
+
 
 ## [v0.5.3][]
 
@@ -215,3 +219,4 @@ descent parser and a work-in-progress state-machine parser.
 [#38]: https://github.com/goodmami/pe/issues/38
 [#44]: https://github.com/goodmami/pe/issues/44
 [#46]: https://github.com/goodmami/pe/issues/46
+[#54]: https://github.com/goodmami/pe/issues/54

--- a/pe/_optimize.py
+++ b/pe/_optimize.py
@@ -242,7 +242,7 @@ def _regex_optional(defn, defs, grpid):
     subdef = defn.args[0]
     d = _regex(defn.args[0], defs, grpid)
     if d.op == RGX:
-        subpat = d.args[0] if subdef.op in (DOT, LIT, CLS) else f'(?:{d.args[0]})'
+        subpat = _regex_maybe_group(subdef.op, d.args[0])
         return Regex(f'{subpat}?')
     else:
         return Optional(d)
@@ -252,7 +252,7 @@ def _regex_star(defn, defs, grpid):
     subdef = defn.args[0]
     d = _regex(subdef, defs, grpid)
     if d.op == RGX:
-        subpat = d.args[0] if subdef.op in (DOT, LIT, CLS) else f'(?:{d.args[0]})'
+        subpat = _regex_maybe_group(subdef.op, d.args[0])
         gid = f'_{next(grpid)}'
         return Regex(f'(?=(?P<{gid}>{subpat}*))(?P={gid})')
     else:
@@ -263,11 +263,17 @@ def _regex_plus(defn, defs, grpid):
     subdef = defn.args[0]
     d = _regex(defn.args[0], defs, grpid)
     if d.op == RGX:
-        subpat = d.args[0] if subdef.op in (DOT, LIT, CLS) else f'(?:{d.args[0]})'
+        subpat = _regex_maybe_group(subdef.op, d.args[0])
         gid = f'_{next(grpid)}'
         return Regex(f'(?=(?P<{gid}>{subpat}+))(?P={gid})')
     else:
         return Plus(d)
+
+
+def _regex_maybe_group(op: Operator, arg: str) -> str:
+    if op in (DOT, CLS) or (op == LIT and len(arg) == 1):
+        return arg
+    return f'(?:{arg})'
 
 
 def _regex_and(defn, defs, grpid):


### PR DESCRIPTION
The regex optimizer did not put a non-capturing group around quantized dots, character classes, or literals, but for literals of length > 2, this meant that only the final character was quantized:

Before:
- `'ab'?` -> `` `ab?` ``
- `'cd'*` -> `` `cd*` ``

Now:
- `'ab?'` -> `` `(?:ab)?` ``
- `'cd'*` -> `` `(?:cd)*` ``

Fixes #54